### PR TITLE
chore(ci): add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,62 @@
+version: 2
+updates:
+  # pnpm workspace — single root lockfile covers all packages/*
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+      day: 'monday'
+      time: '09:00'
+    allow:
+      - dependency-type: 'production'
+    groups:
+      deps-minor-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+    open-pull-requests-limit: 10
+    assignees:
+      - 'Texarkanine'
+    commit-message:
+      prefix: 'fix'
+      include: 'scope'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+      day: 'monday'
+      time: '09:00'
+    allow:
+      - dependency-type: 'development'
+    groups:
+      dev-deps-minor-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+    open-pull-requests-limit: 10
+    assignees:
+      - 'Texarkanine'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+
+  # GitHub Actions dependencies
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+      day: 'monday'
+      time: '09:00'
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+    open-pull-requests-limit: 5
+    assignees:
+      - 'Texarkanine'
+    commit-message:
+      prefix: 'chore(deps-ci)'


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yaml` adapted from `inquirerjs-checkbox-search` for this pnpm monorepo (single root lockfile — one npm entry at `/` covers all workspace packages).
- Splits npm updates into production (`fix` commits) and development (`chore` commits) with grouped minor/patch bumps.
- Adds GitHub Actions updates on the same monthly schedule with `chore(deps-ci)` commits.

## Test plan

- [ ] Verify Dependabot picks up the config after merge (Settings → Code security → Dependabot version updates, or wait for first scheduled run on Monday).
- [ ] Confirm first PRs use the expected commit prefixes: `fix(deps)` for prod, `chore(deps)` for dev, `chore(deps-ci)` for Actions.