### PR TITLE
fix(release): republish agentsmd@1.0.3 and a16n@0.15.4 (M1 rework)

### DIFF
--- a/memory-bank/active/.qa-validation-status
+++ b/memory-bank/active/.qa-validation-status
@@ -1,0 +1,6 @@
+QA: PASS
+task: v1-release-rollout-m1 (rework / "M1.1")
+date: 2026-06-13
+phase: QA
+summary: Rework implementation matches plan. agentsmd path-touching guard + CLI scope-note correction + release-as 0.15.4 all present. Full test suite green (17 packages, agentsmd publish-shape 2/2, CLI workspace-invariant 10/10). No blocking findings; minor non-blocking observations recorded in tasks.md.
+gate: cleared for operator action plan (PR creation, merge-gate, publish, deprecations)

--- a/memory-bank/active/activeContext.md
+++ b/memory-bank/active/activeContext.md
@@ -1,12 +1,18 @@
 # Active Context
 
 ## Current Task: v1-release-rollout-m1
-**Phase:** BUILD - COMPLETE
+**Phase:** REFLECT - COMPLETE
 
 ## What Was Done
-- Set temporary `release-as` in `release-please-config.json`: `@a16njs/plugin-agentsmd` → `1.0.3`, `a16n` → `0.15.3`.
-- Replaced the original per-package `pnpm pack` tests (near-tautological; couldn't catch the npm-vs-pnpm cause) with a single repo-level source-invariant test `packages/cli/test/workspace-publish-invariant.test.ts`: every workspace sibling reference must use `workspace:` in source (invariant #3, repo-wide).
-- Deferred the real artifact-inspection guard (matches the operator's npm-publish error) to M2.
+- Rework build: agentsmd `publish-shape.test.ts` (path-touch + public-access + workspace guard), CLI scope-note correction in `workspace-publish-invariant.test.ts`, `release-as` → CLI `0.15.4` / agentsmd `1.0.3`.
+- QA passed: full suite green, no blocking findings.
+- Reflection captured in `memory-bank/active/reflection/reflection-v1-release-rollout-m1.md`.
+- `techContext.md` updated with Release-Please path-inclusion behavior.
+
+## Operator Follow-Up (not yet done)
+- Open PR with rework commits; confirm generated release PR bumps BOTH `agentsmd → 1.0.3` AND `a16n → 0.15.4` before merge.
+- After publish: verify `npm view @a16njs/plugin-agentsmd@latest dependencies` (exact models pin) and `npx a16n@latest --version`.
+- Optionally deprecate poisoned versions; remove temporary `release-as` keys from `release-please-config.json`.
 
 ## Next Step
-- Run `/niko-qa` for semantic review, then `/niko-reflect` after merge + publish verification.
+- Run `/niko` to continue to the next L4 milestone (M1 operator publish still pending, but sub-run code work is complete).

--- a/memory-bank/active/progress.md
+++ b/memory-bank/active/progress.md
@@ -37,3 +37,38 @@ Restore `a16n@latest` installability by republishing `@a16njs/plugin-agentsmd` a
 * Insights
     - Local `pnpm pack` already rewrites correctly; the breakage was a wrong-tool (`npm publish`) bypass — a property of the publish *command*, not the source tree, so it can only be guarded in the pipeline (M2), not a unit test.
     - A repo-level test must be hosted inside a workspace package (CLI) because `pnpm test` runs `turbo run test` per-package; a root-level test file would not run in CI.
+
+## 2026-06-13 - REWORK INITIATED (post-release failure) - IN-PROGRESS
+
+* Trigger
+    - First M1 release shipped but did not fix the bug. `a16n@0.15.3` is `latest` yet pins poisoned `@a16njs/plugin-agentsmd@1.0.2`; `agentsmd@1.0.3` was never published (`latest` still `1.0.2` with `@a16njs/models: "workspace:*"`). `npx a16n@latest` still throws `EUNSUPPORTEDPROTOCOL`.
+* Corrected root cause
+    - Pipeline publishes via `pnpm --filter publish` (release.yaml:89), not `npm publish` — the prior "wrong tool" insight was incorrect.
+    - Release-Please only releases a package when a commit touches that package's path. PR #119 changed nothing under `packages/plugin-agentsmd/`, so RP excluded agentsmd entirely and `release-as: "1.0.3"` never applied. The CLI released alone and pnpm rewrote its `workspace:*` to the local agentsmd `1.0.2`.
+* Decisions made (operator-approved)
+    - Rework M1 in place rather than spinning a separate M1.1 milestone.
+    - CLI target moves `0.15.3` → `0.15.4` (0.15.3 is immutable and poisoned-by-pin).
+    - Both packages get a real path-touching `fix:` commit so RP includes both in one release PR.
+    - Add an operator merge-gate: the release PR must bump BOTH `agentsmd → 1.0.3` and `a16n → 0.15.4` before merge.
+
+## 2026-06-13 - QA - COMPLETE
+
+* Work completed
+    - Semantic review of the rework against the revised plan (KISS/DRY/YAGNI/completeness/regression/integrity/docs).
+    - Verified the three code-bearing steps: agentsmd `publish-shape.test.ts` (path-touch + public-access + workspace guard), CLI scope-note correction, `release-as` 0.15.4 (cli) / 1.0.3 (agentsmd).
+    - Ran affected suites and full `pnpm test`: all green (17 packages; agentsmd 2/2, CLI invariant 10/10, 190 CLI tests).
+* Result
+    - ✅ PASS. No blocking findings. Cleared to proceed with the operator action plan (PR, merge-gate, publish, optional deprecations).
+* Insights
+    - The agentsmd test's workspace-protocol check duplicates the repo-wide CLI test, but the duplication is load-bearing: only a test under `packages/plugin-agentsmd/` can trigger that package's Release-Please inclusion. Its non-redundant value is the `publishConfig.access` assertion.
+
+## 2026-06-13 - REFLECT - COMPLETE
+
+* Work completed
+    - Authored `memory-bank/active/reflection/reflection-v1-release-rollout-m1.md`.
+    - Reconciled persistent files: surgical `techContext.md` addition documenting Release-Please path-inclusion and `pnpm --filter publish` behavior.
+* Decisions made
+    - M1 sub-run code work is complete; operator merge/publish/verification remains before milestone can be checked off.
+* Insights
+    - A green first release that fails the user story is worse than no release — merge-gate on release PR package inclusion should be standard for multi-package repairs.
+    - Tests placed for CI convenience (repo-wide in CLI) cannot substitute for path-local commits when Release-Please governs what gets published.

--- a/memory-bank/active/projectbrief.md
+++ b/memory-bank/active/projectbrief.md
@@ -36,3 +36,15 @@ A new `@a16njs/plugin-agentsmd` patch (≥ 1.0.3) is published via the automated
 2. After operator merge + publish: `npx a16n@latest --version` succeeds (install + run).
 3. Source `package.json` files for `packages/plugin-agentsmd` and `packages/cli` still use `workspace:*` for internal deps.
 4. A local/pre-merge test proves `pnpm pack` on agentsmd produces a tarball whose `package.json` dependencies contain no `workspace:` protocol.
+
+## Rework (post first-release failure)
+
+The first M1 release did not satisfy AC#1/AC#2: `a16n@0.15.3` published pinning the poisoned `@a16njs/plugin-agentsmd@1.0.2`, and `agentsmd@1.0.3` was never published.
+
+**Corrected understanding:** Release-Please only releases a package when a commit touches that package's path. `release-as` overrides the version *if a release is cut* but does not force one. The original fix touched no file under `packages/plugin-agentsmd/`, so agentsmd was silently excluded from the release.
+
+**Added requirements:**
+- R5. Each package to be republished (`@a16njs/plugin-agentsmd`, `a16n`) MUST receive a real `fix:` commit touching its own path so Release-Please includes it.
+- R6. The CLI target version is `0.15.4` (0.15.3 is immutable and pins the poisoned agentsmd).
+- R7. Operator merge-gate: the generated release PR must bump BOTH `agentsmd → 1.0.3` AND `a16n → 0.15.4` before it is merged. If either is missing, do not merge.
+- R8 (revised AC#4): the pre-merge proof is the existing repo-level source-invariant test plus the per-package path-touching commits; full published-artifact inspection remains M2 scope.

--- a/memory-bank/active/reflection/reflection-v1-release-rollout-m1.md
+++ b/memory-bank/active/reflection/reflection-v1-release-rollout-m1.md
@@ -1,0 +1,38 @@
+---
+task_id: v1-release-rollout-m1
+date: 2026-06-13
+complexity_level: 2
+---
+
+# Reflection: v1-release-rollout-m1
+
+## Summary
+
+Rework after the first M1 release failed delivered the repo changes needed to republish `@a16njs/plugin-agentsmd@1.0.3` and `a16n@0.15.4` together: path-touching guards in each package, corrected release documentation in tests, and forced `release-as` versions. Code and tests are complete and QA-clean; restoring `npx a16n@latest` still depends on operator merge, release-PR verification, and publish.
+
+## Requirements vs Outcome
+
+All code-bearing requirements (R1–R3 source invariants, R5–R8 rework additions) are implemented. Acceptance criteria #1 and #2 remain operator-gated (post-merge publish). AC#4 was reinterpreted during build: per-package `pnpm pack` tests were dropped as near-tautological; the repo-level source-invariant test plus path-touching commits are the pre-merge proof, with tarball inspection deferred to M2. Optional deprecation (R4) was descoped from code and left as an operator checklist item, consistent with the original plan's optional framing.
+
+## Plan Accuracy
+
+The first plan misidentified the failure mode (`npm publish` bypass) and missed Release-Please's path-inclusion rule — `release-as` overrides a version only when a release is cut, it does not force one. Those gaps caused a shipped release that made things worse (`a16n@0.15.3` pinning poisoned `agentsmd@1.0.2`). The rework plan correctly targeted path-touching commits in both packages, burned-version handling (`0.15.4`), and an operator merge-gate. No further plan surprises during rework build or QA.
+
+## Build & QA Observations
+
+The first build phase completed cleanly by conventional metrics (tests green, PR merged) but failed the actual user story — a sharp reminder that semantic correctness beats green CI. Rework build was straightforward once the root cause was corrected: two small test files, a comment rewrite, and a version bump. QA found no blocking issues; the intentional duplication between agentsmd and CLI workspace-protocol tests is load-bearing for Release-Please, not accidental drift.
+
+## Insights
+
+### Technical
+- Release-Please only includes a package in a release when a commit touches that package's path; `release-as` is inert without a path touch.
+- When the CLI publishes with `pnpm --filter publish`, sibling `workspace:*` deps rewrite to whatever version exists locally — if agentsmd was never released, the CLI re-pins the stale poisoned version.
+- Package-scoped tests that must trigger a release belong under that package's path; repo-wide tests in another package cannot substitute.
+
+### Process
+- Before merging any multi-package release PR, verify every target package appears in the manifest bumps — treat a missing package as a stop condition, not a minor oversight.
+- Root-cause analysis should trace the actual publish pipeline (`release.yaml`) before writing tests; a plausible-but-wrong theory (`npm publish`) produced tests that could not catch the real failure mode.
+
+### Million-Dollar Question
+
+If release correctness had been a foundational assumption, every publishable package would ship with in-package publish-shape guards (public access + workspace protocol), the release pipeline would fail CI if any to-be-published tarball contains `workspace:` or pins an absent sibling (M2), and merge would be blocked unless the release PR bumps every package in the intended set — ideally enforced automatically rather than via operator checklist.

--- a/memory-bank/active/tasks.md
+++ b/memory-bank/active/tasks.md
@@ -30,33 +30,41 @@ Republish `@a16njs/plugin-agentsmd` (new patch via automated `pnpm publish` so `
 
 ## Implementation Plan
 
-1. **Repo-level source-invariant test**
+> **REWORK.** The first release (PR #119/#120) failed: agentsmd was never released (no path-touching commit) and the CLI re-pinned the poisoned `1.0.2`. The plan below makes both packages release together, with the CLI moving to `0.15.4`.
+
+1. **Repo-level source-invariant test** *(already landed in first release; keep)*
    - Files: `packages/cli/test/workspace-publish-invariant.test.ts`
-   - Changes: discover all `packages/*/package.json`; for each package, assert every dependency (any bucket) naming another workspace package uses the `workspace:` protocol. Documents in-file that the npm-vs-pnpm cause is M2 scope.
+   - Status: present and passing. Its scope-note comment is corrected in step 3 (it wrongly attributed the breakage to `npm publish`).
 
-2. *(removed — per-package pack test; see Test Plan revision note)*
+2. **agentsmd path-touching trigger + guard**
+   - Files: `packages/plugin-agentsmd/test/publish-shape.test.ts` (new)
+   - Changes: assert agentsmd's `package.json` declares `publishConfig.access === "public"` and uses the `workspace:` protocol for every sibling dep. This is a real regression guard for the two failure modes that have hit this package (missing public access on first publish; leaked `workspace:`), AND it touches the agentsmd path so Release-Please includes agentsmd in the release.
+   - Commit: `fix(plugin-agentsmd): guard published package shape (public access + workspace protocol)`
 
-3. *(removed — CLI pack test; see Test Plan revision note)*
+3. **CLI path-touching trigger + comment correction**
+   - Files: `packages/cli/test/workspace-publish-invariant.test.ts`
+   - Changes: rewrite the inaccurate scope-note (the pipeline uses `pnpm --filter publish`, not `npm publish`; the real M1 failure was a package being absent from the release set). Touches the CLI path so Release-Please includes `a16n` in the release.
+   - Commit: `fix(a16n): correct workspace-invariant test scope note and re-pin agentsmd`
 
-4. **Force Release-Please patch bumps**
+4. **Set forced release versions**
    - Files: `release-please-config.json`
-   - Changes: add per-package `"release-as": "1.0.3"` under `packages/plugin-agentsmd` and `"release-as": "0.15.3"` under `packages/cli`; add changelog-driving commit message (`fix(release): republish agentsmd and cli with rewritten workspace deps`)
+   - Changes: change `packages/cli` `release-as` `"0.15.3"` → `"0.15.4"` (0.15.3 is burned). Keep `packages/plugin-agentsmd` `release-as: "1.0.3"` (never published).
 
-5. **Document republish rationale in changelogs (Release-Please will generate on release PR)**
-   - Files: none in source — RP generates `CHANGELOG.md` entries on the Release PR branch
-   - Changes: ensure commit body explains poisoned-version context for RP changelog parser
+5. **Operator merge-gate (PR description / checklist)**
+   - Files: none (PR description)
+   - Changes: document that the generated release PR MUST bump BOTH `@a16njs/plugin-agentsmd → 1.0.3` AND `a16n → 0.15.4`. If either package is missing from the release PR, do NOT merge — investigate the path-touch.
 
-6. **Remove `release-as` after release (follow-up — operator task post-merge)**
+6. **Remove `release-as` after successful publish (operator follow-up)**
    - Files: `release-please-config.json`
-   - Changes: note in PR description that operator removes temporary `release-as` keys in a follow-up commit after successful publish (or leave until next organic bump — document choice in PR)
+   - Changes: note in PR that operator removes the temporary `release-as` keys post-publish.
 
-7. **Optional deprecation script/instructions**
-   - Files: `scripts/deprecate-poisoned-versions.sh` (new, executable) OR PR test-plan checklist only
-   - Changes: `npm deprecate @a16njs/plugin-agentsmd@1.0.1 "..."` etc.; operator runs manually with npm credentials (not CI)
+7. **Optional deprecation (now includes a16n@0.15.3)**
+   - Files: `scripts/deprecate-poisoned-versions.sh` (optional) OR PR checklist
+   - Changes: `npm deprecate` for `@a16njs/plugin-agentsmd@1.0.1`, `1.0.2`, `a16n@0.15.2`, and now `a16n@0.15.3` (poisoned-by-pin).
 
 8. **Verify locally before PR**
-   - Commands: `pnpm build && pnpm test && pnpm --filter @a16njs/plugin-agentsmd exec pnpm pack` (manual spot-check)
-   - Operator post-merge: `npx a16n@latest --version`
+   - Commands: `pnpm build && pnpm test`
+   - Operator post-merge: `npm view @a16njs/plugin-agentsmd@latest dependencies` (exact models pin) and `npx a16n@latest --version` (exit 0).
 
 ## Technology Validation
 
@@ -82,5 +90,23 @@ No new technology — validation not required. Uses existing pnpm pack/publish, 
 - [x] Implementation plan complete
 - [x] Technology validation complete
 - [x] Preflight
-- [x] Build
-- [ ] QA
+- [x] Build (first attempt — released but did not fix the bug)
+- [x] Rework build (agentsmd + CLI path-touching triggers; CLI → 0.15.4)
+- [x] QA — PASS (semantic review clean; full suite green)
+
+## QA Result (2026-06-13)
+
+✅ **PASS** — the rework implementation matches the plan and all code requirements are satisfied.
+
+- **Completeness**: Plan steps 2–4 (the code-bearing steps) are all implemented:
+  - Step 2: `packages/plugin-agentsmd/test/publish-shape.test.ts` exists, asserts `publishConfig.access === "public"` + workspace protocol on every sibling, and touches the agentsmd path (the path-touch is the load-bearing fix for RP inclusion).
+  - Step 3: CLI `workspace-publish-invariant.test.ts` scope-note rewritten to reflect the real cause (package absent from release set + `pnpm --filter publish`), replacing the inaccurate `npm publish` theory.
+  - Step 4: `release-please-config.json` → CLI `release-as: "0.15.4"`, agentsmd `release-as: "1.0.3"` retained.
+  - Steps 5–8 are operator follow-ups (PR description, deprecations, post-publish verification) — out of scope for code QA.
+- **Regression**: New test mirrors existing conventions (flat `test/`, pure FS reads, Vitest, `PackageManifest`/`DEPENDENCY_BUCKETS` shape from the sibling CLI test). Source `package.json` files still use `workspace:*` — invariant #3 preserved.
+- **Integrity**: No debug artifacts, magic numbers, or placeholder values introduced.
+- **Tests**: `publish-shape.test.ts` (2) and `workspace-publish-invariant.test.ts` (10) pass; full `pnpm test` green (17 packages, 190 CLI tests).
+- **Observations (non-blocking, by design)**:
+  - The agentsmd test's workspace-protocol assertion overlaps the repo-wide CLI test. This duplication is intentional and load-bearing: the assertion must live in the agentsmd package path to trigger a Release-Please release. Its unique value is the `publishConfig.access` check the repo-wide test lacks.
+  - The agentsmd test iterates all four dependency buckets though agentsmd only populates two; this is defensive future-proofing consistent with the sibling test's style.
+  - Plan step 3's commit message says "re-pin agentsmd", but the CLI source change is comment-only (the re-pin happens at publish time via pnpm rewrite). Cosmetic wording note for the not-yet-made commit.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -26,7 +26,7 @@ TypeScript ESM-only monorepo managed by pnpm workspaces, built with Turborepo, t
 ## CI/CD
 
 - **ci.yaml** — build, typecheck, test with coverage, docs build, Codecov upload (per-package flags) on PRs and pushes to main
-- **release.yaml** — Release-Please automation for semantic versioning
+- **release.yaml** — Release-Please automation for semantic versioning; publishes via `pnpm --filter publish` (OIDC trusted publishing). Release-Please only cuts a release for a package when a commit touches that package's path — per-package `release-as` overrides the version *if* a release is cut but does not force inclusion
 - **docs.yaml** — deploy Docusaurus to GitHub Pages
 - **release-lockfile-sync.yaml** — sync pnpm lockfile after releases
 

--- a/packages/cli/test/workspace-publish-invariant.test.ts
+++ b/packages/cli/test/workspace-publish-invariant.test.ts
@@ -10,12 +10,20 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
  * pnpm's publish-time rewrite, so a hand-pinned sibling version in source is a
  * bug (it can silently drift from, or outright contradict, what gets published).
  *
- * Scope note: this does NOT protect against publishing with the wrong tool
- * (`npm publish` instead of `pnpm publish`), which is what produced the original
- * `@a16njs/plugin-agentsmd` breakage. A unit test that reads source manifests
- * cannot observe which command an operator runs. That failure mode is addressed
- * by the release-pipeline hardening in M2 (artifact inspection + removing the
- * need for manual recovery publishes).
+ * Scope note: a source-manifest test like this can only prove the source is
+ * correct — it cannot observe what actually gets published. The release pipeline
+ * publishes via `pnpm --filter publish` (see .github/workflows/release.yaml),
+ * which rewrites `workspace:` to an exact version. Two failure modes therefore
+ * live outside this test:
+ *   1. A package that is absent from the release set never republishes, so a
+ *      consumer (e.g. the CLI) re-pins a stale, still-poisoned sibling version.
+ *      Release-Please only releases a package when a commit touches its path;
+ *      `release-as` alone does not force a release. This is what broke the first
+ *      M1 attempt (agentsmd was never in the release; a16n re-pinned 1.0.2).
+ *   2. Publishing the built tarball with a tool that does not rewrite the
+ *      protocol.
+ * Published-artifact inspection that catches both is M2 (release-pipeline)
+ * scope, not a unit test.
  */
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');

--- a/packages/plugin-agentsmd/test/publish-shape.test.ts
+++ b/packages/plugin-agentsmd/test/publish-shape.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Package-scoped guard for the two failure modes that have specifically bitten
+ * @a16njs/plugin-agentsmd at publish time:
+ *
+ *  1. Missing `publishConfig.access: "public"` — a scoped package without it
+ *     cannot be published publicly on a first publish.
+ *  2. A leaked `workspace:` specifier for a sibling — the source MUST keep
+ *     `workspace:` (pnpm rewrites it to an exact version only at publish time);
+ *     a hand-pinned sibling in source is the bug that produced the original
+ *     poisoned `1.0.1`/`1.0.2` tarballs.
+ *
+ * This file lives in the agentsmd package on purpose: Release-Please only cuts
+ * a release for a package when a commit touches that package's path. A repo-wide
+ * test in another package cannot trigger an agentsmd release, which is exactly
+ * why the first M1 attempt silently shipped without republishing agentsmd.
+ */
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+interface PackageManifest {
+  name?: string;
+  publishConfig?: { access?: string };
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
+
+const DEPENDENCY_BUCKETS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+] as const;
+
+const manifest = JSON.parse(
+  readFileSync(join(packageRoot, 'package.json'), 'utf8')
+) as PackageManifest;
+
+describe('@a16njs/plugin-agentsmd published package shape', () => {
+  it('declares public access so a scoped publish succeeds', () => {
+    expect(manifest.publishConfig?.access).toBe('public');
+  });
+
+  it('keeps every @a16njs/* sibling dependency on the workspace: protocol in source', () => {
+    for (const bucket of DEPENDENCY_BUCKETS) {
+      const deps = manifest[bucket];
+      if (!deps) {
+        continue;
+      }
+      for (const [depName, spec] of Object.entries(deps)) {
+        if (depName.startsWith('@a16njs/')) {
+          expect(spec, `${depName} in ${bucket}`).toMatch(/^workspace:/);
+        }
+      }
+    }
+  });
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
     "packages/cli": {
       "component": "a16n",
       "changelog-path": "CHANGELOG.md",
-      "release-as": "0.15.3"
+      "release-as": "0.15.4"
     },
     "packages/engine": {
       "component": "@a16njs/engine",


### PR DESCRIPTION
## Summary

1. **Fix the failed M1 release** — the first attempt (#119/#120) shipped `a16n@0.15.3` but never republished `@a16njs/plugin-agentsmd`, so `npx a16n@latest` still fails with `EUNSUPPORTEDPROTOCOL` (`workspace:*`).
2. **Add a path-touching release trigger for agentsmd** — [`packages/plugin-agentsmd/test/publish-shape.test.ts`](https://github.com/Texarkanine/a16n/blob/fix-the-releases.m2/packages/plugin-agentsmd/test/publish-shape.test.ts) guards `publishConfig.access: public` and `workspace:` sibling deps; Release-Please only releases a package when a commit touches its path.
3. **Add a path-touching release trigger for the CLI** — correct the scope note in [`packages/cli/test/workspace-publish-invariant.test.ts`](https://github.com/Texarkanine/a16n/blob/fix-the-releases.m2/packages/cli/test/workspace-publish-invariant.test.ts) to document the real failure mode (package absent from release set, not `npm publish`).
4. **Force patch versions** — [`release-please-config.json`](https://github.com/Texarkanine/a16n/blob/fix-the-releases.m2/release-please-config.json): `@a16njs/plugin-agentsmd` → `1.0.3`, `a16n` → `0.15.4` (`0.15.3` is immutable and pins poisoned `agentsmd@1.0.2`).

## Root cause

Release-Please only includes a package in a release when a commit touches that package's path. `release-as` overrides the version **if** a release is cut — it does not force one. PR #119 changed nothing under `packages/plugin-agentsmd/`, so agentsmd was silently excluded; the CLI published alone and pnpm rewrote its `workspace:*` to the local stale `1.0.2`.

## Operator merge-gate (critical)

After this PR merges, Release-Please will open a **release PR**. **Do not merge the release PR unless it bumps BOTH:**

- `@a16njs/plugin-agentsmd` → **1.0.3**
- `a16n` → **0.15.4**

If either package is missing from the release PR, stop and investigate — the path-touch did not register.

## Post-publish verification

```bash
npm view @a16njs/plugin-agentsmd@latest dependencies
# expect exact @a16njs/models semver, NOT workspace:*

npx a16n@latest --version
# expect exit 0
```

## Optional follow-ups (not in this PR)

- `npm deprecate` poisoned versions: `@a16njs/plugin-agentsmd@1.0.1`, `1.0.2`, `a16n@0.15.2`, `a16n@0.15.3`
- Remove temporary `release-as` keys from `release-please-config.json` after successful publish

## Test plan

- [x] `pnpm build && pnpm test` — full suite green (17 packages)
- [x] `@a16njs/plugin-agentsmd` — `publish-shape.test.ts` (2 tests)
- [x] `a16n` — `workspace-publish-invariant.test.ts` (10 tests)
- [ ] After release PR merge + publish: `npm view @a16njs/plugin-agentsmd@latest dependencies` shows exact models pin
- [ ] After release PR merge + publish: `npx a16n@latest --version` succeeds