### PR TITLE
chore(docs): initialize SumMem memory system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ packages/docs/static/**/llms.txt
 packages/docs/static/**/llms-full.txt
 # Per-page .md mirrors from docs:llms:static (img/ is the only committed static content)
 packages/docs/static/**/*.md
+
+# SumMem Python driver bytecode
+**/.summem/__pycache__/

--- a/.summem/config.toml
+++ b/.summem/config.toml
@@ -1,0 +1,3 @@
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32

--- a/.summem/notes/20260820T180626Z-9d85ea6a1aef0587
+++ b/.summem/notes/20260820T180626Z-9d85ea6a1aef0587
@@ -1,0 +1,1 @@
+SumMem onboarded from Texarkanine/SumMem@6f81b669: driver at .summem/summem; stores started at repo root and each packages/* directory

--- a/.summem/notes/20260820T180626Z-b702f66bd5dd27cd
+++ b/.summem/notes/20260820T180626Z-b702f66bd5dd27cd
@@ -1,0 +1,1 @@
+Durable public repository facts go in SumMem; Niko memory-bank/ is task-scoped working documentation archived when the task ends

--- a/.summem/summem
+++ b/.summem/summem
@@ -1,0 +1,1136 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Texarkanine
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""SumMem: Recency-biased file-based concurrent write-tolerant memory for AI agents."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _utf8_stdio() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8")
+        except (OSError, ValueError):
+            pass
+
+
+_utf8_stdio()
+
+
+def note_file_bytes(text: str) -> bytes:
+    """Return UTF-8 encoding of *text* plus a single trailing newline."""
+    return text.encode("utf-8") + b"\n"
+
+
+def note_digest(file_bytes: bytes) -> str:
+    """Return lowercase hex SHA-256 of *file_bytes*."""
+    return hashlib.sha256(file_bytes).hexdigest()
+
+
+def leafset_id(digests: list[str]) -> str:
+    """Return lowercase hex SHA-256 of sorted hex digests joined with no delimiter."""
+    join = "".join(sorted(digests))
+    return hashlib.sha256(join.encode("ascii")).hexdigest()
+
+
+@dataclass(frozen=True)
+class NoteChild:
+    """A raw note child in a canonical tree."""
+
+    name: str
+    text: str
+
+
+@dataclass(frozen=True)
+class Tree:
+    """Canonical tree: list of note and nap children."""
+
+    kids: list[NoteChild | NapChild]
+
+
+@dataclass(frozen=True)
+class NapChild:
+    """A nap child. *id* is the leaf-set id of the original notes."""
+
+    id: str
+    sum: str
+    tree: Tree
+
+
+@dataclass(frozen=True)
+class ViewNode:
+    """One wait-free view entry: a loose note or a nap stem."""
+
+    id: str
+    name: str
+    kind: str
+    caption: str
+    leaves: int
+    stamp: str
+    path: Path
+    sum_path: Path | None = None
+    tree_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class ProjectedNode:
+    """One printed wake row: a view file or an in-memory expanded child."""
+
+    id: str
+    kind: str
+    caption: str
+    leaves: int
+    stamp: str
+    tree: Tree | None = None
+    tree_path: Path | None = None
+    tree_attempted: bool = False
+
+
+def _tree_dict(tree: Tree) -> dict:
+    kids = []
+    for child in tree.kids:
+        if isinstance(child, NoteChild):
+            kids.append({"type": "note", "name": child.name, "text": child.text})
+        else:
+            kids.append(
+                {"type": "nap", "id": child.id, "sum": child.sum, "tree": _tree_dict(child.tree)}
+            )
+    return {"c": kids}
+
+
+def dumps_tree(tree: Tree) -> bytes:
+    """Serialize *tree* to canonical JSON bytes with a trailing newline."""
+    body = json.dumps(_tree_dict(tree), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return body.encode("utf-8") + b"\n"
+
+
+def _tree_from_dict(obj: dict) -> Tree:
+    kids: list[NoteChild | NapChild] = []
+    for child in obj["c"]:
+        kind = child.get("type")
+        if kind == "note":
+            kids.append(NoteChild(name=child["name"], text=child["text"]))
+        elif kind == "nap":
+            kids.append(
+                NapChild(id=child["id"], sum=child["sum"], tree=_tree_from_dict(child["tree"]))
+            )
+        else:
+            raise ValueError("unknown tree child type")
+    return Tree(kids=kids)
+
+
+_TREE_PARSE_ERRORS = (
+    OSError,
+    UnicodeError,
+    json.JSONDecodeError,
+    KeyError,
+    TypeError,
+    ValueError,
+    AttributeError,
+)
+
+
+def loads_tree(data: bytes) -> Tree:
+    """Parse canonical tree bytes into a Tree."""
+    return _tree_from_dict(json.loads(data.decode("utf-8")))
+
+
+ENTRY_CHARS = 280
+WAKE_LINES = 32
+CLI_NAME = "summem"
+AGENT_BIN = ".summem/summem"
+
+CONFIG_TEMPLATE = """\
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32
+"""
+
+
+def require_utc(now):
+    """Reject *now* unless tzinfo is datetime.timezone.utc."""
+    if not isinstance(now, datetime) or now.tzinfo is not timezone.utc:
+        raise ValueError("clock must be UTC")
+    return now
+
+
+def find_store_parent(cwd):
+    """Walk from *cwd* to the first directory that contains .git.
+
+    Raise ValueError if no repository is found.
+    """
+    cur = Path(cwd).resolve()
+    for candidate in (cur, *cur.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    raise ValueError("not in a repository")
+
+
+def is_store(directory):
+    """Return True if *directory* already contains a `.summem/` store."""
+    return (Path(directory) / ".summem").is_dir()
+
+
+def resolve_parent(cwd, path_arg=None):
+    """Return the parent directory of the store that *cwd* / *path_arg* resolve to.
+
+    *path_arg* is a `--path` value or None for `$PWD`. An existing directory is
+    the walk start. Any other path, including a missing file, walks from its
+    parent.     Walk toward the git root and take the first `is_store`. If none,
+    return the git root. Raise ValueError if there is no repository.
+    """
+    origin = Path(cwd).resolve()
+    if path_arg is not None:
+        p = Path(path_arg)
+        if not p.is_absolute():
+            p = origin / p
+        p = p.resolve()
+        origin = p if p.is_dir() else p.parent
+    root = find_store_parent(origin)
+    for candidate in (origin, *origin.parents):
+        if is_store(candidate):
+            return candidate
+        if candidate == root:
+            break
+    return root
+
+
+def ensure_store(parent):
+    """Create notes/, naps/, and default config under *parent* if missing. Does not place the driver."""
+    store = Path(parent) / ".summem"
+    (store / "notes").mkdir(parents=True, exist_ok=True)
+    (store / "naps").mkdir(parents=True, exist_ok=True)
+    config = store / "config.toml"
+    if not config.exists():
+        config.write_text(CONFIG_TEMPLATE, encoding="utf-8")
+    return store
+
+
+def knobs(parent):
+    """Return WAKE_LINES and ENTRY_CHARS for the store under *parent*."""
+    defaults = {"WAKE_LINES": WAKE_LINES, "ENTRY_CHARS": ENTRY_CHARS}
+    config = Path(parent) / ".summem" / "config.toml"
+    try:
+        data = tomllib.loads(config.read_text(encoding="utf-8"))
+        result = dict(defaults)
+        if "WAKE_LINES" in data:
+            result["WAKE_LINES"] = int(data["WAKE_LINES"])
+        if "ENTRY_CHARS" in data:
+            result["ENTRY_CHARS"] = int(data["ENTRY_CHARS"])
+        return result
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, TypeError, ValueError, AttributeError):
+        return defaults
+
+
+def _ignored_store(git_root: Path, store_dir: Path) -> bool:
+    rel = store_dir.relative_to(git_root).as_posix()
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "--", rel],
+        cwd=git_root,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def catalog_text(git_root, resolved_parent) -> str:
+    """Return root-wake catalog of other started stores, or empty."""
+    root = Path(git_root).resolve()
+    if Path(resolved_parent).resolve() != root:
+        return ""
+    found: list[Path] = []
+    for dirpath, dirnames, _filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [name for name in dirnames if name != ".git"]
+        if ".summem" not in dirnames:
+            continue
+        parent = Path(dirpath)
+        dirnames.remove(".summem")
+        if parent.resolve() == root:
+            continue
+        store_dir = parent / ".summem"
+        if _ignored_store(root, store_dir):
+            continue
+        found.append(parent)
+    found.sort()
+    if not found:
+        return ""
+    lines = ["== Additional SumMem Catalogs =="]
+    for parent in found:
+        rel = parent.relative_to(root).as_posix()
+        lines.append(f"./{rel}")
+    return "\n".join(lines) + "\n"
+
+
+def require_entry(text: str, entry_chars: int | None = None) -> None:
+    """Reject empty, multi-line, or over-long one-line entries."""
+    limit = ENTRY_CHARS if entry_chars is None else entry_chars
+    if text == "":
+        raise ValueError("note is empty")
+    if "\n" in text or "\r" in text:
+        raise ValueError("One line only. Merge the lines.")
+    n = len(text.encode("utf-8"))
+    if n > limit:
+        raise ValueError(
+            f"Too long: {n} bytes, limit {limit}. "
+            "Accented characters cost 2 bytes. Compress it further."
+        )
+
+
+def _replace_bytes(dest: Path, data: bytes) -> None:
+    tmp = dest.parent / f".tmp-{os.urandom(8).hex()}"
+    tmp.write_bytes(data)
+    os.replace(tmp, dest)
+
+
+def _seq_prefix(name: str) -> str:
+    """Return the {stamp}-{rand} order key from a note or nap filename."""
+    return "-".join(name.split("-")[:2])
+
+
+def _parse_nap_stem(stem: str) -> tuple[str, str, str, int] | None:
+    parts = stem.split("-")
+    if len(parts) != 4:
+        return None
+    stamp, rand, leafset, leaves_s = parts
+    if len(stamp) != 16 or len(rand) != 16 or len(leafset) != 64 or not leaves_s.isdigit():
+        return None
+    if any(c not in "0123456789abcdef" for c in rand + leafset):
+        return None
+    return stamp, rand, leafset, int(leaves_s)
+
+
+def _nap_caption(sum_path: Path | None) -> str:
+    if sum_path is None or not sum_path.is_file():
+        return ""
+    try:
+        text = sum_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+    if "<" * 7 in text:
+        return ""
+    if text.endswith("\n"):
+        text = text[:-1]
+    return text
+
+
+def list_view(parent) -> list[ViewNode]:
+    """Return mixed view nodes sorted by filename."""
+    store = ensure_store(parent)
+    nodes: list[ViewNode] = []
+    notes = store / "notes"
+    for path in notes.iterdir():
+        if not path.is_file() or path.name.startswith("."):
+            continue
+        try:
+            raw = path.read_bytes()
+            text = raw.decode("utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if text.endswith("\n"):
+            text = text[:-1]
+        stamp = path.name.split("-")[0]
+        nodes.append(
+            ViewNode(
+                id=leafset_id([note_digest(raw)]),
+                name=path.name,
+                kind="note",
+                caption=text,
+                leaves=1,
+                stamp=stamp,
+                path=path,
+            )
+        )
+    stems: dict[str, dict[str, Path]] = {}
+    naps = store / "naps"
+    for path in naps.iterdir():
+        if not path.is_file() or path.name.startswith("."):
+            continue
+        if path.suffix not in (".sum", ".tree"):
+            continue
+        stems.setdefault(path.stem, {})[path.suffix] = path
+    for stem, files in stems.items():
+        parsed = _parse_nap_stem(stem)
+        if parsed is None:
+            continue
+        stamp, _, leafset, leaves = parsed
+        sum_path = files.get(".sum")
+        tree_path = files.get(".tree")
+        nodes.append(
+            ViewNode(
+                id=leafset,
+                name=stem,
+                kind="nap",
+                caption=_nap_caption(sum_path),
+                leaves=leaves,
+                stamp=stamp,
+                path=tree_path or sum_path or naps / stem,
+                sum_path=sum_path,
+                tree_path=tree_path,
+            )
+        )
+    nodes.sort(key=lambda node: node.name)
+    return nodes
+
+
+def _note_child(node: ViewNode) -> tuple[NoteChild, str]:
+    raw = node.path.read_bytes()
+    return NoteChild(name=node.name, text=node.caption), note_digest(raw)
+
+
+def _digests_of_tree(tree: Tree) -> list[str]:
+    out: list[str] = []
+    for child in tree.kids:
+        if isinstance(child, NoteChild):
+            out.append(note_digest(note_file_bytes(child.text)))
+        else:
+            out.extend(_digests_of_tree(child.tree))
+    return out
+
+
+def _note_children(tree: Tree):
+    for child in tree.kids:
+        if isinstance(child, NoteChild):
+            yield child
+        else:
+            yield from _note_children(child.tree)
+
+
+def leaf_digests(node: ViewNode) -> set[str] | None:
+    """Return the leaf digest set of *node*, or None if a nap pack is unreadable."""
+    if node.kind == "note":
+        try:
+            return {note_digest(node.path.read_bytes())}
+        except OSError:
+            return None
+    if node.tree_path is None or not node.tree_path.is_file():
+        return None
+    try:
+        return set(_digests_of_tree(loads_tree(node.tree_path.read_bytes())))
+    except _TREE_PARSE_ERRORS:
+        return None
+
+
+def _nap_stem(child: NapChild) -> str:
+    """Return `{leftmost-seq}-{child.id}-{leaves}` for a rematerialized NapChild."""
+    leftmost = next(_note_children(child.tree))
+    leaves = len(_digests_of_tree(child.tree))
+    return f"{_seq_prefix(leftmost.name)}-{child.id}-{leaves}"
+
+
+def rematerialize_child(parent, child: NoteChild | NapChild) -> None:
+    """Copy *child* bytes into the store without overwriting an existing dest."""
+    store = ensure_store(parent)
+    if isinstance(child, NoteChild):
+        dest = store / "notes" / child.name
+        if dest.exists():
+            return
+        _replace_bytes(dest, note_file_bytes(child.text))
+        return
+    stem = _nap_stem(child)
+    naps = store / "naps"
+    tree_path = naps / f"{stem}.tree"
+    sum_path = naps / f"{stem}.sum"
+    if not tree_path.exists():
+        _replace_bytes(tree_path, dumps_tree(child.tree))
+    if not sum_path.exists():
+        _replace_bytes(sum_path, note_file_bytes(child.sum))
+
+
+def _first_overlap(
+    nodes: list[ViewNode],
+) -> tuple[ViewNode, ViewNode, set[str], set[str]] | None:
+    sets = [leaf_digests(node) for node in nodes]
+    for i, left in enumerate(nodes):
+        for j in range(i + 1, len(nodes)):
+            right = nodes[j]
+            left_set, right_set = sets[i], sets[j]
+            if left_set is None or right_set is None:
+                continue
+            if left.kind == "note" and right.kind == "note":
+                continue
+            if left_set.isdisjoint(right_set):
+                continue
+            if left.leaves <= right.leaves:
+                return left, right, left_set, right_set
+            return right, left, right_set, left_set
+    return None
+
+
+def heal_view(parent) -> None:
+    """Zipper overlapping view packs until a pass cannot mutate."""
+    while True:
+        found = _first_overlap(list_view(parent))
+        if found is None:
+            return
+        smaller, other, small_set, other_set = found
+        if small_set <= other_set:
+            _unlink_node(smaller)
+            continue
+        if other_set <= small_set:
+            _unlink_node(other)
+            continue
+        child, _digests = _as_child(smaller)
+        for kid in child.tree.kids:
+            rematerialize_child(parent, kid)
+        _unlink_node(smaller)
+
+
+def with_store_lock(parent, fn):
+    """Run *fn* while holding an exclusive flock on the store's naps/ directory."""
+    store = ensure_store(parent)
+    fd = os.open(store / "naps", os.O_RDONLY)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        return fn()
+    finally:
+        os.close(fd)
+
+
+def _as_child(node: ViewNode) -> tuple[NoteChild | NapChild, list[str]]:
+    if node.kind == "note":
+        child, digest = _note_child(node)
+        return child, [digest]
+    if node.tree_path is None or not node.tree_path.is_file():
+        raise ValueError("unknown id")
+    try:
+        inner = loads_tree(node.tree_path.read_bytes())
+    except _TREE_PARSE_ERRORS:
+        raise ValueError("unreadable pack") from None
+    return NapChild(id=node.id, sum=node.caption, tree=inner), _digests_of_tree(inner)
+
+
+def _unlink_node(node: ViewNode) -> None:
+    if node.kind == "note":
+        node.path.unlink()
+        return
+    if node.sum_path is not None and node.sum_path.is_file():
+        node.sum_path.unlink()
+    if node.tree_path is not None and node.tree_path.is_file():
+        node.tree_path.unlink()
+
+
+def _adjacent_nodes(nodes: list[ViewNode], id_a: str, id_b: str) -> tuple[ViewNode, ViewNode]:
+    hits_a = [i for i, node in enumerate(nodes) if node.id == id_a]
+    hits_b = [i for i, node in enumerate(nodes) if node.id == id_b]
+    if not hits_a or not hits_b:
+        raise ValueError("unknown id. Copy an id from wake.")
+    for ia in hits_a:
+        for ib in hits_b:
+            if ia == ib:
+                continue
+            if abs(ia - ib) == 1:
+                lo, hi = (ia, ib) if ia < ib else (ib, ia)
+                return nodes[lo], nodes[hi]
+    raise ValueError("not adjacent. Nap two ids that sit next to each other in wake.")
+
+
+def write_nap(parent, id_a, id_b, caption, entry_chars: int | None = None):
+    """Fold two adjacent view nodes into a nap pair. Return the .sum path."""
+    require_entry(caption, entry_chars)
+    nodes = list_view(parent)
+    left, right = _adjacent_nodes(nodes, id_a, id_b)
+    child_l, digs_l = _as_child(left)
+    child_r, digs_r = _as_child(right)
+    if (set(digs_l) & set(digs_r)) and (left.kind == "nap" or right.kind == "nap"):
+        raise ValueError("overlapping packs")
+    tree = Tree(kids=[child_l, child_r])
+    digests = digs_l + digs_r
+    leafset = leafset_id(digests)
+    leaves = len(digests)
+    stem = f"{_seq_prefix(left.name)}-{leafset}-{leaves}"
+    naps = ensure_store(parent) / "naps"
+    tree_path = naps / f"{stem}.tree"
+    sum_path = naps / f"{stem}.sum"
+    _replace_bytes(tree_path, dumps_tree(tree))
+    _replace_bytes(sum_path, note_file_bytes(caption))
+    _unlink_node(left)
+    _unlink_node(right)
+    return sum_path
+
+
+def _zoom_note_line(text: str) -> str:
+    cid = leafset_id([note_digest(note_file_bytes(text))])
+    return f"{cid}  {text}"
+
+
+def _zoom_kids(tree: Tree) -> str:
+    lines = []
+    for child in tree.kids:
+        if isinstance(child, NoteChild):
+            lines.append(_zoom_note_line(child.text))
+        elif child.sum:
+            lines.append(f"{child.id}  {child.sum}")
+        else:
+            lines.append(child.id)
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"
+
+
+def _find_in_tree(tree: Tree, cid: str) -> NapChild | str | None:
+    for child in tree.kids:
+        if isinstance(child, NoteChild):
+            if leafset_id([note_digest(note_file_bytes(child.text))]) == cid:
+                return child.text
+            continue
+        if child.id == cid:
+            return child
+        found = _find_in_tree(child.tree, cid)
+        if found is not None:
+            return found
+    return None
+
+
+def _warn_skipped_pack() -> None:
+    """Write one agent-safe line when a sibling children file is unreadable."""
+    sys.stderr.write("skipped a pack\n")
+
+
+def zoom_text(parent, token: str) -> str:
+    """Return one-level zoom of *token* (full id or unique prefix), or raise ValueError if unknown."""
+    cid = resolve_id(token, named_ids(parent))
+    nodes = list_view(parent)
+    for node in nodes:
+        if node.id != cid:
+            continue
+        if node.kind == "note":
+            return f"{node.id}  {node.caption}\n"
+        if node.tree_path is None or not node.tree_path.is_file():
+            raise ValueError("unknown id")
+        try:
+            return _zoom_kids(loads_tree(node.tree_path.read_bytes()))
+        except _TREE_PARSE_ERRORS:
+            raise ValueError("unreadable pack") from None
+    for node in nodes:
+        if node.kind != "nap" or node.tree_path is None or not node.tree_path.is_file():
+            continue
+        try:
+            found = _find_in_tree(loads_tree(node.tree_path.read_bytes()), cid)
+        except _TREE_PARSE_ERRORS:
+            _warn_skipped_pack()
+            continue
+        if found is None:
+            continue
+        if isinstance(found, str):
+            return f"{cid}  {found}\n"
+        return _zoom_kids(found.tree)
+    raise ValueError("unknown id. Copy an id from wake.")
+
+
+def _collect_ids(tree: Tree, ids: list[str]) -> None:
+    for child in tree.kids:
+        if isinstance(child, NoteChild):
+            ids.append(leafset_id([note_digest(note_file_bytes(child.text))]))
+        else:
+            ids.append(child.id)
+            _collect_ids(child.tree, ids)
+
+
+def named_ids(parent) -> list[str]:
+    """Return view ids plus nested tree ids that zoom can already name."""
+    ids: list[str] = []
+    seen: set[str] = set()
+
+    def add(cid: str) -> None:
+        if cid not in seen:
+            seen.add(cid)
+            ids.append(cid)
+
+    for node in list_view(parent):
+        add(node.id)
+        if node.kind != "nap" or node.tree_path is None or not node.tree_path.is_file():
+            continue
+        try:
+            nested: list[str] = []
+            _collect_ids(loads_tree(node.tree_path.read_bytes()), nested)
+        except (OSError, UnicodeDecodeError, ValueError, TypeError, KeyError):
+            continue
+        for cid in nested:
+            add(cid)
+    return ids
+
+
+def expand_frontier(nodes: list[ViewNode], budget: int) -> list[ProjectedNode]:
+    """Return a printed frontier of *nodes*, expanding naps while shorter than *budget*."""
+    if budget <= 0:
+        return []
+    if len(nodes) >= budget:
+        nodes = nodes[-budget:]
+    frontier = [
+        ProjectedNode(
+            id=node.id,
+            kind=node.kind,
+            caption=node.caption,
+            leaves=node.leaves,
+            stamp=node.stamp,
+            tree_path=node.tree_path,
+        )
+        for node in nodes
+    ]
+    while len(frontier) < budget:
+        idx = -1
+        kids: list[ProjectedNode] | None = None
+        for i in range(len(frontier) - 1, -1, -1):
+            row = _prepare_nap(frontier[i])
+            frontier[i] = row
+            split = _split_kids(row)
+            if split is not None:
+                idx = i
+                kids = split
+                break
+        if kids is None:
+            break
+        frontier = [*frontier[:idx], *kids, *frontier[idx + 1 :]]
+    if len(frontier) > budget:
+        frontier = frontier[-budget:]
+    return frontier
+
+
+def _prepare_nap(row: ProjectedNode) -> ProjectedNode:
+    if row.kind != "nap" or row.tree_attempted:
+        return row
+    if row.tree is not None:
+        return replace(row, tree_attempted=True)
+    if row.tree_path is None or not row.tree_path.is_file():
+        return replace(row, tree_attempted=True)
+    try:
+        tree = loads_tree(row.tree_path.read_bytes())
+    except _TREE_PARSE_ERRORS:
+        return replace(row, tree_attempted=True)
+    return replace(row, tree=tree, tree_attempted=True)
+
+
+def _split_kids(row: ProjectedNode) -> list[ProjectedNode] | None:
+    try:
+        if row.tree is None or len(row.tree.kids) != 2:
+            return None
+        kids = [_projected_child(child) for child in row.tree.kids]
+    except (TypeError, ValueError, AttributeError, KeyError):
+        return None
+    if any(kid is None for kid in kids):
+        return None
+    return kids
+
+
+def _projected_child(child: NoteChild | NapChild) -> ProjectedNode | None:
+    if isinstance(child, NoteChild):
+        return ProjectedNode(
+            id=leafset_id([note_digest(note_file_bytes(child.text))]),
+            kind="note",
+            caption=child.text,
+            leaves=1,
+            stamp=child.name.split("-")[0],
+        )
+    notes = list(_note_children(child.tree))
+    if not notes:
+        return None
+    return ProjectedNode(
+        id=child.id,
+        kind="nap",
+        caption=child.sum,
+        leaves=len(notes),
+        stamp=min(note.name.split("-")[0] for note in notes),
+        tree=child.tree,
+    )
+
+
+def write_note(parent, text, now, rng, entry_chars: int | None = None):
+    """Validate *text*, write one immutable note under *parent*, return its path."""
+    require_utc(now)
+    require_entry(text, entry_chars)
+    notes = ensure_store(parent) / "notes"
+    name = f"{now.strftime('%Y%m%dT%H%M%SZ')}-{rng.randbytes(8).hex()}"
+    dest = notes / name
+    _replace_bytes(dest, note_file_bytes(text))
+    return dest
+
+
+def short_id(cid: str, ids: list[str], floor: int = 8) -> str:
+    """Return a unique prefix of *cid* among distinct *ids*, at least *floor* hex characters."""
+    ids = list(dict.fromkeys(ids))
+    n = min(max(floor, 1), len(cid))
+    while n < len(cid):
+        prefix = cid[:n]
+        if sum(1 for item in ids if item.startswith(prefix)) == 1:
+            return prefix
+        n += 1
+    return cid
+
+
+def resolve_id(token: str, ids: list[str]) -> str:
+    """Return the unique id in *ids* that *token* prefixes. Raise ValueError if none or many."""
+    ids = list(dict.fromkeys(ids))
+    matches = [item for item in ids if item.startswith(token)]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        raise ValueError("unknown id. Copy an id from wake.")
+    raise ValueError("ambiguous id. Give a longer prefix.")
+
+
+def format_wake_line(node, ids: list[str]) -> str:
+    """Return one wake line for *node* using unique prefixes from *ids*."""
+    if node.kind == "note" or node.leaves <= 1:
+        return node.caption
+    prefix = short_id(node.id, ids)
+    if node.caption:
+        return f"x{node.leaves} {prefix}: {node.caption}"
+    return f"x{node.leaves} {prefix}:"
+
+
+def wake_text(parent) -> str:
+    """Return the wait-free listing of the mixed view under *parent*, or empty."""
+    nodes = list_view(parent)
+    frontier = expand_frontier(nodes, knobs(parent)["WAKE_LINES"])
+    ids = [item.id for item in nodes]
+    for row in frontier:
+        if row.id not in ids:
+            ids.append(row.id)
+    lines = [format_wake_line(row, ids) for row in frontier]
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"
+
+
+def equal_grain_pair(nodes: list[ViewNode]) -> tuple[str, str] | None:
+    """Return the oldest adjacent same-leaf-count file ids, or None."""
+    for i in range(len(nodes) - 1):
+        if nodes[i].leaves == nodes[i + 1].leaves:
+            return nodes[i].id, nodes[i + 1].id
+    return None
+
+
+def fold_request(parent, wake_lines: int | None = None) -> str:
+    """Return an OptMem-style nap prompt for the oldest equal-grain pair when over *wake_lines*."""
+    if wake_lines is None:
+        wake_lines = WAKE_LINES
+    nodes = list_view(parent)
+    if len(nodes) <= wake_lines:
+        return ""
+    left = right = None
+    for i in range(len(nodes) - 1):
+        if nodes[i].leaves == nodes[i + 1].leaves:
+            left, right = nodes[i], nodes[i + 1]
+            break
+    if left is None:
+        return ""
+    ids = [node.id for node in nodes]
+    remain = len(nodes) - 1 - wake_lines
+    extra = ""
+    if remain == 1:
+        extra = "1 compression remains after this one.\n"
+    elif remain > 1:
+        extra = f"{remain} compressions remain after this one.\n"
+    limit = knobs(parent)["ENTRY_CHARS"]
+    return (
+        f"Compress these two into one line of at most {limit} characters.\n"
+        "Keep what has lasting effect, drop what does not. Invent nothing.\n"
+        "\n"
+        f"  {format_wake_line(left, ids)}\n"
+        f"  {format_wake_line(right, ids)}\n"
+        "\n"
+        f'Run: {AGENT_BIN} nap {short_id(left.id, ids)} {short_id(right.id, ids)} "<your line>"\n'
+        f"{extra}"
+    )
+
+
+def _recall_nested(tree: Tree, rx, lines: list[str], seen: set[str]) -> None:
+    """Append recall hits from *tree* (original notes and nested nap captions) to *lines*."""
+    for child in tree.kids:
+        if isinstance(child, NoteChild):
+            if not rx.search(child.text):
+                continue
+            cid = leafset_id([note_digest(note_file_bytes(child.text))])
+            line = f"{cid}  {child.text}"
+            if line not in seen:
+                lines.append(line)
+                seen.add(line)
+            continue
+        if rx.search(child.sum):
+            line = f"{child.id}  {child.sum}"
+            if line not in seen:
+                lines.append(line)
+                seen.add(line)
+        _recall_nested(child.tree, rx, lines, seen)
+
+
+def recall_text(parent, pattern: str) -> str:
+    """Return matching view lines, nested nap captions, and original notes for *pattern*."""
+    rx = re.compile(pattern)
+    lines = []
+    seen: set[str] = set()
+    nodes = list_view(parent)
+    ids = [node.id for node in nodes]
+    for node in nodes:
+        line = format_wake_line(node, ids)
+        if rx.search(line):
+            lines.append(line)
+            seen.add(line)
+    for node in nodes:
+        if node.kind != "nap" or node.tree_path is None or not node.tree_path.is_file():
+            continue
+        try:
+            _recall_nested(loads_tree(node.tree_path.read_bytes()), rx, lines, seen)
+        except _TREE_PARSE_ERRORS:
+            _warn_skipped_pack()
+            continue
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"
+
+
+def is_range_token(token: str) -> bool:
+    """Return True if *token* is a positional range rather than a content id."""
+    if token.startswith("#"):
+        return True
+    left, sep, right = token.partition("-")
+    return bool(sep) and left.isdigit() and right.isdigit()
+
+
+def require_python(version_info: tuple[int, ...] = sys.version_info) -> None:
+    """Refuse to run on Python older than 3.11."""
+    if version_info < (3, 11):
+        sys.stderr.write("SumMem needs Python 3.11 or newer\n")
+        raise SystemExit(1)
+
+
+def prompt_text() -> str:
+    """Return the agent prompt pasted at the top of AGENTS.md."""
+    return f"""\
+# Project Memory
+
+Shared memory for this repository is managed through SumMem: run `{AGENT_BIN} -h` for usage information. Scoped memory stores may exist; `--path` aimed at a file retrieves memories from the nearest store.
+
+## At Session Start: Activating SumMem (Mandatory)
+
+If you can see a prior **root** SumMem wake in this conversation, skip `wake`.
+
+Otherwise run `{AGENT_BIN} wake` from the repository root.
+
+## While Working: Register Memories (Mandatory)
+
+`{AGENT_BIN} note "…"` records one short line. Call it whenever you learn a fact about this project that another contributor would still need: designs, decisions, invariants, and the like. A note must still be true after a fresh clone on another machine. Personal, machine-local, and user preference facts stay out. If `note` asks for a nap, do that nap before your next action.
+
+Do not register redundant memories.
+
+Never invent filenames, rewrite note bytes, or delete memory files by hand. The script is the only writer. The files it writes are part of your work; do not leave them untracked.
+
+## Other commands
+
+- `{AGENT_BIN} recall <regex>` — search remembered text word for word
+- `{AGENT_BIN} zoom <id>` — any memory with a `x<N> <hash>: …` prefix is a nap that can be zoomed in on.
+- `{AGENT_BIN} wake --path <path>` — when you work under a cataloged path, pull that store if its wake is not already in this conversation. Ignore `--path` if the root wake didn't have a catalog.
+"""
+
+
+def init_text() -> str:
+    """Return the full `init` print: paste recipe plus prompt_text()."""
+    return (
+        "Paste this at the top of AGENTS.md. "
+        "If Claude Code should see it too,"
+        "\n"
+        "put @AGENTS.md at the top of CLAUDE.md.\n"
+        "\n"
+        f"{prompt_text()}"
+    )
+
+
+def usage_text() -> str:
+    """Return the top-level command catalog printed by missing command and -h."""
+    return f"""\
+SumMem: shared memory for agents in a repository.
+
+  {CLI_NAME} wake    [--path PATH]                    print this store's view
+  {CLI_NAME} note    [--path PATH] TEXT               record one line
+  {CLI_NAME} nap     [--path PATH] ID-A ID-B CAPTION  fold two adjacent ids
+  {CLI_NAME} zoom    [--path PATH] ID                 open a nap to its children
+  {CLI_NAME} recall  [--path PATH] PATTERN            search remembered text
+  {CLI_NAME} start <path>                             create a store in that directory
+  {CLI_NAME} init                                     print the agent prompt to paste
+
+Every command except start and init takes optional --path. Omit it to use $PWD.
+--path aims at a file or directory and walks up to the nearest store.
+
+For a command's options: {CLI_NAME} <command> -h
+"""
+
+
+_COMMANDS = ("wake", "note", "nap", "zoom", "recall", "start", "init")
+_HELP_FLAGS = ("-h", "--help")
+
+
+def _cli_argv(argv: list[str] | None) -> list[str]:
+    """Return a copy of CLI arguments. None means sys.argv[1:]."""
+    if argv is None:
+        return sys.argv[1:]
+    return list(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run a SumMem subcommand. Return 0 on success, 2 on usage, 1 on validation."""
+    require_python()
+    args_list = _cli_argv(argv)
+    if not args_list:
+        sys.stderr.write(usage_text())
+        return 2
+    if args_list[0] in _HELP_FLAGS:
+        if len(args_list) == 1 or args_list[1] not in _COMMANDS:
+            sys.stdout.write(usage_text())
+            return 0
+        args_list = [args_list[1], "--help", *args_list[2:]]
+    parser = argparse.ArgumentParser(prog="summem")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    wake = sub.add_parser("wake")
+    note = sub.add_parser("note")
+    note.add_argument("text")
+    nap = sub.add_parser("nap")
+    nap.add_argument("id_a")
+    nap.add_argument("id_b")
+    nap.add_argument("caption")
+    zoom = sub.add_parser("zoom")
+    zoom.add_argument("id")
+    recall = sub.add_parser("recall")
+    recall.add_argument("pattern")
+    start = sub.add_parser("start")
+    start.add_argument("dir")
+    sub.add_parser("init")
+    for parser_with_path in (wake, note, nap, zoom, recall):
+        parser_with_path.add_argument("--path", help="aim at this file or directory")
+    try:
+        args = parser.parse_args(args_list)
+    except SystemExit as exc:
+        return 0 if exc.code is None else int(exc.code)
+    if args.cmd == "start":
+        target = Path(args.dir)
+        if not target.is_absolute():
+            target = Path.cwd() / target
+        probe = target if target.exists() else target.parent
+        try:
+            find_store_parent(probe)
+        except ValueError as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 1
+        target.mkdir(parents=True, exist_ok=True)
+        ensure_store(target)
+        return 0
+    if args.cmd == "init":
+        sys.stdout.write(init_text())
+        return 0
+    try:
+        parent = resolve_parent(Path.cwd(), args.path)
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+    k = knobs(parent)
+    if args.cmd == "wake":
+        doc = wake_text(parent)
+        cat = catalog_text(find_store_parent(parent), parent)
+        footer = "You are up to speed.\n"
+        if cat:
+            if doc:
+                sys.stdout.write(cat + "\n== Project-root Memories ==\n" + doc + footer)
+            else:
+                sys.stdout.write(cat + footer)
+        else:
+            sys.stdout.write(doc + footer)
+        return 0
+    if args.cmd == "nap":
+        for token in (args.id_a, args.id_b):
+            if is_range_token(token):
+                sys.stderr.write(f"not a content id: {token}. Copy an id from wake.\n")
+                return 2
+        try:
+            require_entry(args.caption, k["ENTRY_CHARS"])
+        except ValueError as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 1
+
+        def nap_locked():
+            heal_view(parent)
+            view_ids = [node.id for node in list_view(parent)]
+            id_a = resolve_id(args.id_a, view_ids)
+            id_b = resolve_id(args.id_b, view_ids)
+            write_nap(parent, id_a, id_b, args.caption, k["ENTRY_CHARS"])
+            return fold_request(parent, k["WAKE_LINES"])
+
+        try:
+            out = with_store_lock(parent, nap_locked)
+        except ValueError as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 1
+        sys.stdout.write(out)
+        return 0
+    if args.cmd == "zoom":
+        if is_range_token(args.id):
+            sys.stderr.write(f"not a content id: {args.id}. Copy an id from wake.\n")
+            return 2
+        try:
+            sys.stdout.write(zoom_text(parent, args.id))
+        except ValueError as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 1
+        return 0
+    if args.cmd == "recall":
+        try:
+            sys.stdout.write(recall_text(parent, args.pattern))
+        except re.error:
+            sys.stderr.write("invalid pattern\n")
+            return 2
+        return 0
+    if args.cmd != "note":
+        sys.stderr.write(usage_text())
+        return 2
+    try:
+        require_entry(args.text, k["ENTRY_CHARS"])
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+    now = datetime.now(timezone.utc)
+    rng = random.SystemRandom()
+
+    def note_locked():
+        write_note(parent, args.text, now, rng, k["ENTRY_CHARS"])
+        heal_view(parent)
+        return fold_request(parent, k["WAKE_LINES"])
+
+    try:
+        out = with_store_lock(parent, note_locked)
+    except ValueError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+    sys.stdout.write(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Otherwise run `.summem/summem wake` from the repository root.
 
 ## While Working: Register Memories (Mandatory)
 
-`.summem/summem note "…"` records one short line. Call it whenever you learn a fact about this project that another contributor would still need: designs, decisions, invariants, and the like. A note must still be true after a fresh cloneon another machine. Personal, machine-local, and user preference facts stay out. If `note` asks for a nap, do that napbefore your next action.
+`.summem/summem note "…"` records one short line. Call it whenever you learn a fact about this project that another contributor would still need: designs, decisions, invariants, and the like. A note must still be true after a fresh clone on another machine. Personal, machine-local, and user preference facts stay out. If `note` asks for a nap, do that napbefore your next action.
 
 Do not register redundant memories.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Project Memory
+
+Shared memory for this repository is managed through SumMem: run `.summem/summem -h` for usage information. Scoped memory stores may exist; `--path` aimed at a file retrieves memories from the nearest store.
+
+## At Session Start: Activating SumMem (Mandatory)
+
+If you can see a prior **root** SumMem wake in this conversation, skip `wake`.
+
+Otherwise run `.summem/summem wake` from the repository root.
+
+## While Working: Register Memories (Mandatory)
+
+`.summem/summem note "…"` records one short line. Call it whenever you learn a fact about this project that another contributor would still need: designs, decisions, invariants, and the like. A note must still be true after a fresh cloneon another machine. Personal, machine-local, and user preference facts stay out. If `note` asks for a nap, do that napbefore your next action.
+
+Do not register redundant memories.
+
+Never invent filenames, rewrite note bytes, or delete memory files by hand. The script is the only writer. The files it writes are part of your work; do not leave them untracked.
+
+## Other commands
+
+- `.summem/summem recall <regex>` — search remembered text word for word
+- `.summem/summem zoom <id>` — any memory with a `x<N> <hash>: …` prefix is a nap that can be zoomed in on.
+- `.summem/summem wake --path <path>` — when you work under a cataloged path, pull that store if its wake is not already in this conversation. Ignore `--path` if the root wake didn't have a catalog.
+
+# Agent context
+
+Tracked agent-facing project knowledge lives under `memory-bank/`. Prefer those files over inventing project facts. SumMem is committed concurrent memory for durable repository facts; Niko's `memory-bank/` is task-scoped working documentation.
+
+## Persistent files
+
+- `memory-bank/productContext.md` — business context: users, use cases, success criteria, constraints
+- `memory-bank/systemPatterns.md` — architecture and naming patterns in use
+- `memory-bank/techContext.md` — stack, tools, and how to work in this repo
+
+## Archives
+
+Completed work is summarized under `memory-bank/archive/<kind>/YYYYMMDD-<task-id>.md`.
+
+## Active work
+
+`memory-bank/active/` holds the current-task execution trace. If those files exist, an in-flight task may be underway — consult them before starting work that could collide.
+
+## When to load
+
+When the task needs project, architecture, or stack context, read the relevant persistent file(s). Do not load every memory-bank file on every chat. Package-scoped SumMem facts live in the cataloged stores under `packages/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Never invent filenames, rewrite note bytes, or delete memory files by hand. The 
 
 # Agent context
 
-Tracked agent-facing project knowledge lives under `memory-bank/`. Prefer those files over inventing project facts. SumMem is committed concurrent memory for durable repository facts; Niko's `memory-bank/` is task-scoped working documentation.
+Tracked agent-facing project knowledge lives under `memory-bank/`. Prefer those files over inventing project facts.
 
 ## Persistent files
 
@@ -42,4 +42,4 @@ Completed work is summarized under `memory-bank/archive/<kind>/YYYYMMDD-<task-id
 
 ## When to load
 
-When the task needs project, architecture, or stack context, read the relevant persistent file(s). Do not load every memory-bank file on every chat. Package-scoped SumMem facts live in the cataloged stores under `packages/`.
+When the task needs project, architecture, or stack context, read the relevant persistent file(s). Do not load every memory-bank file on every chat. The algorithm and store layout live in `docs/architecture/index.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/cli/.summem/config.toml
+++ b/packages/cli/.summem/config.toml
@@ -1,0 +1,3 @@
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32

--- a/packages/docs/.summem/config.toml
+++ b/packages/docs/.summem/config.toml
@@ -1,0 +1,3 @@
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32

--- a/packages/engine/.summem/config.toml
+++ b/packages/engine/.summem/config.toml
@@ -1,0 +1,3 @@
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32

--- a/packages/glob-hook/.summem/config.toml
+++ b/packages/glob-hook/.summem/config.toml
@@ -1,0 +1,3 @@
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32

--- a/packages/models/.summem/config.toml
+++ b/packages/models/.summem/config.toml
@@ -1,0 +1,3 @@
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32

--- a/packages/plugin-a16n/.summem/config.toml
+++ b/packages/plugin-a16n/.summem/config.toml
@@ -1,0 +1,3 @@
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32

--- a/packages/plugin-agentsmd/.summem/config.toml
+++ b/packages/plugin-agentsmd/.summem/config.toml
@@ -1,0 +1,3 @@
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32

--- a/packages/plugin-claude/.summem/config.toml
+++ b/packages/plugin-claude/.summem/config.toml
@@ -1,0 +1,3 @@
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32

--- a/packages/plugin-cursor/.summem/config.toml
+++ b/packages/plugin-cursor/.summem/config.toml
@@ -1,0 +1,3 @@
+# SumMem per-store settings. Missing values take the script's defaults.
+# ENTRY_CHARS = 280
+# WAKE_LINES = 32


### PR DESCRIPTION
<!-- Title: conventional commit. Squash-merge uses the title as the commit message and,
     when the repo cuts releases from conventional commits (e.g. release-please), as the
     changelog entry — so write it for someone reading history or CHANGELOG.md. feat/fix
     typically cut a release in those setups; chore typically does not. -->

## Goal

Onboard [SumMem](https://github.com/Texarkanine/SumMem) at the repository root and in every monorepo package so agents can record durable, clone-portable facts.

## What's here

Vendored the SumMem driver and activated it for this repo. No a16n CLI or library behavior changed. The branch matches the Goal: root store plus a started store under each `packages/*` directory.

* Added [.summem/summem](https://github.com/Texarkanine/a16n/blob/summem/.summem/summem) (driver from Texarkanine/SumMem@6f81b669)
* Added [AGENTS.md](https://github.com/Texarkanine/a16n/blob/summem/AGENTS.md) with the official activation block at the top
* Added [CLAUDE.md](https://github.com/Texarkanine/a16n/blob/summem/CLAUDE.md) as `@AGENTS.md` so Claude Code sees the same prompt
* Started stores (each a [.summem/config.toml](https://github.com/Texarkanine/a16n/blob/summem/packages/cli/.summem/config.toml)) under [packages/cli](https://github.com/Texarkanine/a16n/tree/summem/packages/cli), [docs](https://github.com/Texarkanine/a16n/tree/summem/packages/docs), [engine](https://github.com/Texarkanine/a16n/tree/summem/packages/engine), [glob-hook](https://github.com/Texarkanine/a16n/tree/summem/packages/glob-hook), [models](https://github.com/Texarkanine/a16n/tree/summem/packages/models), [plugin-a16n](https://github.com/Texarkanine/a16n/tree/summem/packages/plugin-a16n), [plugin-agentsmd](https://github.com/Texarkanine/a16n/tree/summem/packages/plugin-agentsmd), [plugin-claude](https://github.com/Texarkanine/a16n/tree/summem/packages/plugin-claude), and [plugin-cursor](https://github.com/Texarkanine/a16n/tree/summem/packages/plugin-cursor)
* Ignored `**/.summem/__pycache__/` in [.gitignore](https://github.com/Texarkanine/a16n/blob/summem/.gitignore)
* Recorded two root notes: onboard source/layout, and SumMem vs Niko `memory-bank/` split

## How I know it works

This is repo-tooling, not product code, so the a16n test suite is the wrong evidence. I ran the driver: `start` on all nine packages, then root `wake`. Wake printed the catalog of those paths and the two notes. [AGENTS.md](https://github.com/Texarkanine/a16n/blob/summem/AGENTS.md) was written from the driver's `prompt_text()` so the activation block matches the script.

**Evidence:**

<details>
<summary>Transcript</summary>

```
== Additional SumMem Catalogs ==
./packages/cli
./packages/docs
./packages/engine
./packages/glob-hook
./packages/models
./packages/plugin-a16n
./packages/plugin-agentsmd
./packages/plugin-claude
./packages/plugin-cursor

== Project-root Memories ==
SumMem onboarded from Texarkanine/SumMem@6f81b669: driver at .summem/summem; stores started at repo root and each packages/* directory
Durable public repository facts go in SumMem; Niko memory-bank/ is task-scoped working documentation archived when the task ends
You are up to speed.
```

</details>

## What changes for a user

Nothing user-visible for a16n CLI or library consumers. Agents and contributors in this repository now opt in via [AGENTS.md](https://github.com/Texarkanine/a16n/blob/summem/AGENTS.md) and record notes with `.summem/summem`. Package-scoped facts resolve to the started store under that package.
